### PR TITLE
Update Makefile, fix the compile error, library dependencies order issue.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS=-O -g -lreadline
 objs = prudbg.o cmdinput.o cmd.o printhelp.o da.o uio.o
 
 prudebug : ${objs}
-	${CC} ${CFLAGS}  ${objs} -o prudebug
+	${CC} ${objs} -o prudebug ${CFLAGS}
 
 clean:
 	rm -f ${objs} prudebug


### PR DESCRIPTION
fix the compile error, library dependencies order issue.
https://stackoverflow.com/questions/45135/why-does-the-order-in-which-libraries-are-linked-sometimes-cause-errors-in-gcc