### PR TITLE
Fix segfault in rl_prep_terminal

### DIFF
--- a/cmdinput.c
+++ b/cmdinput.c
@@ -26,6 +26,10 @@ int cmd_input(char *prompt, char *cmd, char *cmdargs, unsigned int *argptrs, uns
 {
 	unsigned int		i, j, full_len, on_zero;
 
+
+	rl_instream = stdin;
+	rl_outstream = stdout;
+
 	rl_prep_terminal(0);
 	rl_tty_set_echoing(1);
 	char * buf = readline(prompt);


### PR DESCRIPTION
The call to `rl_prep_terminal` was causing a segfault on my BeagleBone Black:

```
debian@beaglebone:~/prudebug-rl$ uname -a
Linux beaglebone 5.10.168-ti-r65 #1bullseye SMP PREEMPT Thu Jul 20 17:00:01 UTC 2023 armv7l GNU/Linux

debian@beaglebone:~/prudebug-rl$ sudo ./prudebug 
PRU Debugger v0.25
(C) Copyright 2011, 2013 by Arctica Technologies.  All rights reserved.
Written by Steven Anderson

Using /dev/mem device.
Processor type          AM335x
PRUSS memory address    0x4a300000
PRUSS memory length     0x00040000

         offsets below are in 32-bit word addresses (not ARM byte addresses)
         PRU            Instruction    Data         Ctrl
         0              0x0000d000     0x00000000   0x00008800
         1              0x0000e000     0x00000800   0x00009000

Segmentation fault
```

This patch initializes `rl_instream` and `rl_outstream` prior to calling `rl_prep_terminal(0)`.

See https://lists.gnu.org/archive/html/bug-readline/2020-11/msg00001.html for more info about readline initialization behavior.